### PR TITLE
Replace remaining Repl.it project links with code-viewer embeds

### DIFF
--- a/_pages/Activities/activity-arraysworkshop.md
+++ b/_pages/Activities/activity-arraysworkshop.md
@@ -38,10 +38,6 @@ info:
       title: Sample 2D Array Free Response Question
     - link: https://runestone.academy/ns/books/published//csawesome/Unit6-Arrays/numberCubeB.html
       title: Sample Array Free Response Question   
-    - link: https://repl.it/@BillJr99/NumberCubeTemplate
-      title: Number Cube Example
-    - link: https://repl.it/@BillJr99/RouteCipherTemplate
-      title: Route Cipher Example      
       
 tags:
   - arrays
@@ -49,3 +45,15 @@ tags:
   
 ---
 
+
+## Example Templates
+
+You can explore and download these starter templates:
+
+### Number Cube Example
+
+<iframe height="500px" width="100%" src="https://www.billmongan.com/Ursinus-CS173/assets/code-viewer.html?zip=https%3A%2F%2Fraw.githubusercontent.com%2FBillJr99%2FUrsinus-CS173%2Fgh-pages%2Ffiles%2Freplit%2FNumberCubeTemplate.zip&title=Number%20Cube%20Example" scrolling="yes" frameborder="no" allowfullscreen="true" sandbox="allow-scripts allow-same-origin"></iframe>
+
+### Route Cipher Example
+
+<iframe height="500px" width="100%" src="https://www.billmongan.com/Ursinus-CS173/assets/code-viewer.html?zip=https%3A%2F%2Fraw.githubusercontent.com%2FBillJr99%2FUrsinus-CS173%2Fgh-pages%2Ffiles%2Freplit%2FRouteCipherTemplate.zip&title=Route%20Cipher%20Example" scrolling="yes" frameborder="no" allowfullscreen="true" sandbox="allow-scripts allow-same-origin"></iframe>

--- a/_pages/Activities/activity-functions.md
+++ b/_pages/Activities/activity-functions.md
@@ -44,7 +44,7 @@ info:
       questions:
         - What does <code>return</code> mean in the <code>circleArea</code> function above?
         - Notice that functions have data types before their function names, just like variables do.  What is the return type of <code>circleArea()</code>?
-        - Try running the sample program above in repl.it. 
+        - Try running the sample program above in a development environment of your choice. 
         - Modify the program to write an additional function circleDiameter() that computes the diameter (<span>\(2 \times \pi \times r\)</span>) given the radius of the circle.  Call that function from main() and print the value.
         - Modify the program to write and call <code>triangleArea()</code> from <code>main()</code> and then print the area of a triangle whose dimensions you choose.
         - "What do you think is the function defintion for <code>Math.pow</code>, <code>Math.sqrt</code>, and <code>System.out.println</code>?" 

--- a/_pages/Activities/activity-inheritance.md
+++ b/_pages/Activities/activity-inheritance.md
@@ -178,7 +178,7 @@ info:
         - Does an <code>interface</code> define fields, methods, both, or neither?
         - What is the advantage of defining an <code>interface</code>?
         - When using an <code>interface</code>, it is sometimes still necessary to duplicate code.  Can you find an example of this in this Model?
-        - Run this example in <a href=https://repl.it>repl.it</a>.  What must each file be named, and what code goes into which file?  When you click Run, what <code>javac</code> command executes (specifically, what files are compiled)?   
+        - Run this example in a development environment of your choice.  What must each file be named, and what code goes into which file?  When you click Run, what <code>javac</code> command executes (specifically, what files are compiled)?   
     - model: |
         <script type="syntaxhighlighter" class="brush: cpp"><![CDATA[  
         import java.util.Random;


### PR DESCRIPTION
Replit is being retired. This cleans up the remaining repl.it references in the activity pages (the DrawingCanvas pages were already handled, and the activity iframes were already converted).

**Changes**
- Converted the two `repl.it/@BillJr99/...` project links in the arrays workshop (`NumberCubeTemplate`, `RouteCipherTemplate`) into `code-viewer.html` embeds of the existing `files/replit/*.zip` archives, added under a short "Example Templates" section.
- Neutralized two prose mentions that told students to run code "in repl.it" (`activity-functions`, `activity-inheritance`).

Generic `replit.com` references (e.g. in `module-replit.md`) are left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)